### PR TITLE
docs: correct argument order for sign() function of '@noble/ed25519' in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import { sign } from '@noble/ed25519';
   // Get transaction hash, it is used in signing
   const txHash = hash(rawTx);
   // Then use `ed25519` library to sign the hash with your private key
-  const sig = sign(myPrivateKey, txHash);
+  const sig = sign(txHash, myPrivateKey);
   // And finally sign tx (actualy it concatenates bytes)
   const signedTx = spawnTpl.sign(rawTx, sig);
 


### PR DESCRIPTION
[Reference](https://github.com/paulmillr/noble-ed25519)
```ts
function sign(
  message: Hex, // message which would be signed
  privateKey: Hex // 32-byte private key
): Uint8Array;

function signAsync(message: Hex, privateKey: Hex): Promise<Uint8Array>;
````